### PR TITLE
Update action versions to upgrade to Node.js 20

### DIFF
--- a/validate-ctv/action.yml
+++ b/validate-ctv/action.yml
@@ -14,7 +14,7 @@ runs:
   using: 'composite'
   steps:
     - if: inputs.run-only != 'true'
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - if: inputs.run-only != 'true'
       uses: r-lib/actions/setup-r@v2
@@ -30,7 +30,7 @@ runs:
 
     - if: inputs.run-only != 'true'
       name: Cache R packages
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ${{ env.R_LIBS_USER }}
         key: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('.github/depends.Rds') }}


### PR DESCRIPTION
Node.js 16 is now deprecated in Github Actions, so we need to update the actions that we are using to upgrade to Node.js 20.