### PR TITLE
Improve handling of events that aren't pull requests

### DIFF
--- a/validate-ctv/README.md
+++ b/validate-ctv/README.md
@@ -2,8 +2,7 @@
 
 This GitHub Action validates proposed changes to a CRAN task view. It is 
 designed for use in the `cran-task-views` GitHub organization, but can
-be run in any user repository using the `user` option. By default, it will
-also run on the 1st of every month to check for deprecated packages.
+be run in any user repository using the `user` option.
 
 # Using this workflow
 
@@ -41,3 +40,10 @@ jobs:
 Replace `<TaskViewName>` with the name of the task view. The task view should be
 contained in a file named `TaskViewName.md` in the `user/TaskViewName` GitHub 
 repository.
+
+# Scheduling workflows
+
+By default, the above `.yml` will trigger the workflow to check for archived packages
+at [5:30 am on the 1st of every month](https://crontab.guru/#30_5_1_*_*).
+If you would not like to trigger monthly workflows, you can modify the `cron` value
+or remove the `schedule` component entirely. See more details [here](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#schedule).

--- a/validate-ctv/README.md
+++ b/validate-ctv/README.md
@@ -2,7 +2,8 @@
 
 This GitHub Action validates proposed changes to a CRAN task view. It is 
 designed for use in the `cran-task-views` GitHub organization, but can
-be run in any user repository using the `user` option.
+be run in any user repository using the `user` option. By default, it will
+also run on the 1st of every month to check for deprecated packages.
 
 # Using this workflow
 
@@ -25,6 +26,8 @@ on:
     paths:
       - '.github/workflows/validate-ctv.yml'
       - '<TaskViewName>.md'
+  schedule:
+    - cron: '30 5 1 * *'
 
 name: Validate task view
 

--- a/validate-ctv/action.yml
+++ b/validate-ctv/action.yml
@@ -71,7 +71,7 @@ runs:
           } else {
             previousArchive <- ctv::check_ctv_packages(
               paste0("https://raw.githubusercontent.com/${{ inputs.user }}/",
-                     basename(getwd()), "/main/", basename(getwd()), ".md"
+                     basename(getwd()), "/${{ github.base_ref || github.ref_name }}/", basename(getwd()), ".md"
               ))[["Packages in packagelist but archived on CRAN"]]
             newArchives <- setdiff(archived, previousArchive)
             if (length(newArchives)) {

--- a/validate-ctv/action.yml
+++ b/validate-ctv/action.yml
@@ -63,16 +63,23 @@ runs:
 
         archived <- result[[4]]
         if (length(archived)) {
-          previousArchive <- ctv::check_ctv_packages(
-           paste0("https://raw.githubusercontent.com/${{ inputs.user }}/",
-           basename(getwd()), "/main/", basename(getwd()), ".md"
-          ))[["Packages in packagelist but archived on CRAN"]]
-          newArchives <- setdiff(archived, previousArchive)
-          if (length(newArchives)) {
+          if ("${{ github.event_name }}" != "pull_request") {
+            stop(
+              "Archived packages in packagelist:\n - ",
+              paste0(archived, collapse = "\n - ")
+            )
+          } else {
+            previousArchive <- ctv::check_ctv_packages(
+              paste0("https://raw.githubusercontent.com/${{ inputs.user }}/",
+                     basename(getwd()), "/main/", basename(getwd()), ".md"
+              ))[["Packages in packagelist but archived on CRAN"]]
+            newArchives <- setdiff(archived, previousArchive)
+            if (length(newArchives)) {
               stop(
                 "Adding archived packages:\n - ",
                 paste0(newArchives, collapse = "\n - ")
               )
+            }
           }
         }
       shell: Rscript {0}


### PR DESCRIPTION
Currently, [it's recommended](https://github.com/cran-task-views/ctv/tree/main/validate-ctv) that the workflow be set to run if a push OR pull_request is made. However, if a push was made to the main branch and there were any new packages that were archived on CRAN, these wouldn't be caught because the script checks against the version on the main branch (so there would never be a diff of archived packages). Now, if the event that triggered the workflow is not a pull request, the workflow fails if there are ANY archived packages, regardless of what the version on main looks like. This also now makes it work for scheduled jobs, so I've added the recommendation that the workflow be scheduled to run once a month.